### PR TITLE
Convert important highlighter action into toggle action

### DIFF
--- a/src/main/java/com/github/alisonli/historyplugin/actions/HighlightImportantHistoryAction.java
+++ b/src/main/java/com/github/alisonli/historyplugin/actions/HighlightImportantHistoryAction.java
@@ -1,46 +1,52 @@
 package com.github.alisonli.historyplugin.actions;
 
-import com.github.alisonli.historyplugin.ImportantCommitsHighlighter;
-import com.github.alisonli.historyplugin.services.DiffAnalyzerService;
-import com.intellij.openapi.actionSystem.AnAction;
+import com.github.alisonli.historyplugin.highlighters.HighlighterFactory;
+import com.github.alisonli.historyplugin.highlighters.ImportantCommitsHighlighter;
 import com.intellij.openapi.actionSystem.AnActionEvent;
+import com.intellij.openapi.actionSystem.Presentation;
+import com.intellij.openapi.actionSystem.ToggleAction;
+import com.intellij.openapi.actionSystem.Toggleable;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.vcs.*;
 import com.intellij.openapi.vcs.actions.VcsContextUtil;
 import com.intellij.openapi.vfs.VirtualFile;
-import com.intellij.vcs.log.data.VcsLogData;
+import com.intellij.vcs.log.VcsLogHighlighter;
 import com.intellij.vcs.log.history.FileHistoryUi;
-import com.intellij.vcs.log.impl.VcsProjectLog;
 import com.intellij.vcs.log.ui.VcsLogInternalDataKeys;
 import com.intellij.vcs.log.util.VcsLogUtil;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.*;
 
-public class HighlightImportantHistoryAction extends AnAction {
+public class HighlightImportantHistoryAction extends ToggleAction {
     private static final Logger LOG = Logger.getInstance(HighlightImportantHistoryAction.class);
 
     @Override
     public void update(@NotNull AnActionEvent e) {
-        Project project = e.getProject();
-        e.getPresentation().setVisible(project != null && ProjectLevelVcsManager.getInstance(project).hasActiveVcss());
+        boolean selected = isSelected(e);
+        final Presentation presentation = e.getPresentation();
+        Toggleable.setSelected(presentation, selected);
     }
 
     @Override
-    public void actionPerformed(@NotNull AnActionEvent e) {
-        Project project = Objects.requireNonNull(e.getProject());
-        FileHistoryUi logUi = e.getRequiredData(VcsLogInternalDataKeys.FILE_HISTORY_UI);
-        List<FilePath> selectedFiles = VcsContextUtil.selectedFilePaths(e.getDataContext());
-
-        VirtualFile root = VcsLogUtil.getActualRoot(project, selectedFiles.get(0));
-
-        highlightImportantCommits(project, root, logUi, DiffAnalyzerService.getImportantCommits(project, root, logUi));
+    public boolean isSelected(@NotNull AnActionEvent e) {
+        return Toggleable.isSelected(e.getPresentation());
     }
 
-    private void highlightImportantCommits(Project project, VirtualFile root, FileHistoryUi ui,
-                                           Set<Integer> importantCommits) {
-        VcsLogData logData = VcsProjectLog.getInstance(project).getLogManager().getDataManager();
-        ui.getTable().addHighlighter(new ImportantCommitsHighlighter(ui, logData, root, importantCommits));
+    @Override
+    public void setSelected(@NotNull AnActionEvent e, boolean state) {
+        Project project = Objects.requireNonNull(e.getProject());
+        List<FilePath> selectedFiles = VcsContextUtil.selectedFilePaths(e.getDataContext());
+        VirtualFile root = VcsLogUtil.getActualRoot(project, selectedFiles.get(0));
+        FileHistoryUi logUi = e.getRequiredData(VcsLogInternalDataKeys.FILE_HISTORY_UI);
+        VcsLogHighlighter highlighter =
+                new HighlighterFactory(project, root, logUi).getHighlighter(HighlighterFactory.Type.IMPORTANT);
+        if (!state) {
+            logUi.getTable().removeHighlighter(highlighter);
+            ImportantCommitsHighlighter.disposeInstance();
+        } else {
+            logUi.getTable().addHighlighter(highlighter);
+        }
     }
 }

--- a/src/main/java/com/github/alisonli/historyplugin/highlighters/HighlighterFactory.java
+++ b/src/main/java/com/github/alisonli/historyplugin/highlighters/HighlighterFactory.java
@@ -1,0 +1,35 @@
+package com.github.alisonli.historyplugin.highlighters;
+
+import com.github.alisonli.historyplugin.services.DiffAnalyzerService;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.vcs.log.VcsLogHighlighter;
+import com.intellij.vcs.log.data.VcsLogData;
+import com.intellij.vcs.log.history.FileHistoryUi;
+import com.intellij.vcs.log.impl.VcsProjectLog;
+
+import java.util.Objects;
+import java.util.Set;
+
+public class HighlighterFactory {
+    private final Project myProject;
+    private final VirtualFile myRoot;
+    private final FileHistoryUi myUi;
+
+    public HighlighterFactory(Project project, VirtualFile root, FileHistoryUi logUi) {
+        myProject = project;
+        myRoot = root;
+        myUi = logUi;
+    }
+
+    public VcsLogHighlighter getHighlighter(Type type) {
+        // Can switch highlighter types based on input type when more highlighters are added
+        VcsLogData logData = Objects.requireNonNull(VcsProjectLog.getInstance(myProject).getLogManager()).getDataManager();
+        Set<Integer> importantCommits = DiffAnalyzerService.getImportantCommits(myProject, myRoot, myUi);
+        return ImportantCommitsHighlighter.getInstance(myUi, logData, myRoot, importantCommits);
+    }
+
+    public enum Type {
+        IMPORTANT
+    }
+}

--- a/src/main/java/com/github/alisonli/historyplugin/highlighters/ImportantCommitsHighlighter.java
+++ b/src/main/java/com/github/alisonli/historyplugin/highlighters/ImportantCommitsHighlighter.java
@@ -1,4 +1,4 @@
-package com.github.alisonli.historyplugin;
+package com.github.alisonli.historyplugin.highlighters;
 
 import com.github.alisonli.historyplugin.services.DiffAnalyzerService;
 import com.intellij.openapi.vfs.VirtualFile;
@@ -14,6 +14,7 @@ import java.util.Arrays;
 import java.util.Set;
 
 public class ImportantCommitsHighlighter implements VcsLogHighlighter {
+    private static ImportantCommitsHighlighter INSTANCE;
     private final FileHistoryUi myUi;
     private final VcsLogData myLogData;
     private final VirtualFile myRoot;
@@ -22,12 +23,24 @@ public class ImportantCommitsHighlighter implements VcsLogHighlighter {
     private static final Color REGULAR_TEXT_COLOR = new Color(235, 98, 52);
     private static final Color DARK_TEXT_COLOR = new Color(235, 210, 52);
 
-    public ImportantCommitsHighlighter(FileHistoryUi ui, @Nullable VcsLogData logData,
+    private ImportantCommitsHighlighter(FileHistoryUi ui, @Nullable VcsLogData logData,
                                        VirtualFile root, @Nullable Set<Integer> commits) {
         myUi = ui;
         myLogData = logData;
         myRoot = root;
         myImportantCommits = commits;
+    }
+
+    public static ImportantCommitsHighlighter getInstance(FileHistoryUi ui, @Nullable VcsLogData logData,
+                                                   VirtualFile root, @Nullable Set<Integer> commits) {
+        if (INSTANCE == null) {
+            INSTANCE = new ImportantCommitsHighlighter(ui, logData, root, commits);
+        }
+        return INSTANCE;
+    }
+
+    public static void disposeInstance() {
+        INSTANCE = null;
     }
 
     @Override


### PR DESCRIPTION
The commit highlighting is now a toggleable action with the following changes added:
- A factory class has been added in case there is a desire to add different highlighters in the future.
- The `ImportantCommitsHighlighter` has been converted to a singleton so that removal of the highlighter can be toggled.

Resolves #12.