### PR TITLE
Refactor highlighter factory to use flyweight pattern

### DIFF
--- a/src/main/java/com/github/alisonli/historyplugin/actions/HighlightImportantHistoryAction.java
+++ b/src/main/java/com/github/alisonli/historyplugin/actions/HighlightImportantHistoryAction.java
@@ -1,7 +1,6 @@
 package com.github.alisonli.historyplugin.actions;
 
 import com.github.alisonli.historyplugin.highlighters.HighlighterFactory;
-import com.github.alisonli.historyplugin.highlighters.ImportantCommitsHighlighter;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.actionSystem.Presentation;
 import com.intellij.openapi.actionSystem.ToggleAction;
@@ -38,13 +37,13 @@ public class HighlightImportantHistoryAction extends ToggleAction {
     public void setSelected(@NotNull AnActionEvent e, boolean state) {
         Project project = Objects.requireNonNull(e.getProject());
         List<FilePath> selectedFiles = VcsContextUtil.selectedFilePaths(e.getDataContext());
-        VirtualFile root = VcsLogUtil.getActualRoot(project, selectedFiles.get(0));
+        FilePath path = selectedFiles.get(0);
+        VirtualFile root = VcsLogUtil.getActualRoot(project, path);
         FileHistoryUi logUi = e.getRequiredData(VcsLogInternalDataKeys.FILE_HISTORY_UI);
-        VcsLogHighlighter highlighter =
-                new HighlighterFactory(project, root, logUi).getHighlighter(HighlighterFactory.Type.IMPORTANT);
+        VcsLogHighlighter highlighter = HighlighterFactory.getHighlighter(project, root, path, logUi);
         if (!state) {
             logUi.getTable().removeHighlighter(highlighter);
-            ImportantCommitsHighlighter.disposeInstance();
+            HighlighterFactory.disposeHighlighter(path);
         } else {
             logUi.getTable().addHighlighter(highlighter);
         }

--- a/src/main/java/com/github/alisonli/historyplugin/highlighters/HighlighterFactory.java
+++ b/src/main/java/com/github/alisonli/historyplugin/highlighters/HighlighterFactory.java
@@ -2,34 +2,34 @@ package com.github.alisonli.historyplugin.highlighters;
 
 import com.github.alisonli.historyplugin.services.DiffAnalyzerService;
 import com.intellij.openapi.project.Project;
+import com.intellij.openapi.vcs.FilePath;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.vcs.log.VcsLogHighlighter;
 import com.intellij.vcs.log.data.VcsLogData;
 import com.intellij.vcs.log.history.FileHistoryUi;
 import com.intellij.vcs.log.impl.VcsProjectLog;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 
 public class HighlighterFactory {
-    private final Project myProject;
-    private final VirtualFile myRoot;
-    private final FileHistoryUi myUi;
+    private static final Map<FilePath, VcsLogHighlighter> HIGHLIGHTER_CACHE = new HashMap<>();
 
-    public HighlighterFactory(Project project, VirtualFile root, FileHistoryUi logUi) {
-        myProject = project;
-        myRoot = root;
-        myUi = logUi;
+    private HighlighterFactory() {
     }
 
-    public VcsLogHighlighter getHighlighter(Type type) {
-        // Can switch highlighter types based on input type when more highlighters are added
-        VcsLogData logData = Objects.requireNonNull(VcsProjectLog.getInstance(myProject).getLogManager()).getDataManager();
-        Set<Integer> importantCommits = DiffAnalyzerService.getImportantCommits(myProject, myRoot, myUi);
-        return ImportantCommitsHighlighter.getInstance(myUi, logData, myRoot, importantCommits);
+    public static VcsLogHighlighter getHighlighter(Project project, VirtualFile root, FilePath path,
+                                                   FileHistoryUi logUi) {
+        return HIGHLIGHTER_CACHE.computeIfAbsent(path, k -> {
+            VcsLogData logData = Objects.requireNonNull(VcsProjectLog.getInstance(project).getLogManager()).getDataManager();
+            Set<Integer> importantCommits = DiffAnalyzerService.getImportantCommits(project, root, logUi);
+            return new ImportantCommitsHighlighter(logUi, logData, root, importantCommits);
+        });
     }
 
-    public enum Type {
-        IMPORTANT
+    public static void disposeHighlighter(FilePath path) {
+        HIGHLIGHTER_CACHE.remove(path);
     }
 }

--- a/src/main/java/com/github/alisonli/historyplugin/highlighters/ImportantCommitsHighlighter.java
+++ b/src/main/java/com/github/alisonli/historyplugin/highlighters/ImportantCommitsHighlighter.java
@@ -14,7 +14,6 @@ import java.util.Arrays;
 import java.util.Set;
 
 public class ImportantCommitsHighlighter implements VcsLogHighlighter {
-    private static ImportantCommitsHighlighter INSTANCE;
     private final FileHistoryUi myUi;
     private final VcsLogData myLogData;
     private final VirtualFile myRoot;
@@ -23,24 +22,12 @@ public class ImportantCommitsHighlighter implements VcsLogHighlighter {
     private static final Color REGULAR_TEXT_COLOR = new Color(235, 98, 52);
     private static final Color DARK_TEXT_COLOR = new Color(235, 210, 52);
 
-    private ImportantCommitsHighlighter(FileHistoryUi ui, @Nullable VcsLogData logData,
+    public ImportantCommitsHighlighter(FileHistoryUi ui, @Nullable VcsLogData logData,
                                        VirtualFile root, @Nullable Set<Integer> commits) {
         myUi = ui;
         myLogData = logData;
         myRoot = root;
         myImportantCommits = commits;
-    }
-
-    public static ImportantCommitsHighlighter getInstance(FileHistoryUi ui, @Nullable VcsLogData logData,
-                                                   VirtualFile root, @Nullable Set<Integer> commits) {
-        if (INSTANCE == null) {
-            INSTANCE = new ImportantCommitsHighlighter(ui, logData, root, commits);
-        }
-        return INSTANCE;
-    }
-
-    public static void disposeInstance() {
-        INSTANCE = null;
     }
 
     @Override


### PR DESCRIPTION
Previously, the important commits highlighter was a singleton with instantiation controlled by the highlighter factory. This implementation ignored the case where a user opens more than one file history log, then only one highlighter at a time would be in use and deletion of the highlighter would not track all previously created highlighters if the user toggled highlighting.

For now, this flyweight implementation uses a cache that maps a file path to its instantiated important commits highlighter. Later, the type of the value could be changed to a collection of highlighters if more than one highlighter is used on a file history.