### PR TITLE
Bump plugin version to 1.0.0

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -13,7 +13,7 @@ pluginUntilBuild = 221.*
 
 # IntelliJ Platform Properties -> https://github.com/JetBrains/gradle-intellij-plugin#intellij-platform-properties
 platformType = IC
-platformVersion = 2022.1
+platformVersion = LATEST-EAP-SNAPSHOT
 
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html
 # Example: platformPlugins = com.intellij.java, com.jetbrains.php:203.4449.22

--- a/src/main/java/com/alisli/intelligenthistory/settings/JiraConfig.java
+++ b/src/main/java/com/alisli/intelligenthistory/settings/JiraConfig.java
@@ -53,6 +53,9 @@ public class JiraConfig implements PersistentStateComponent<JiraConfig> {
 
     @Transient
     public String getPassword() {
+        if (username == null) {
+            return "";
+        }
         CredentialAttributes credentialAttributes = createCredentialAttributes(username);
         return PasswordSafe.getInstance().getPassword(credentialAttributes);
     }

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -8,7 +8,7 @@
     <depends>Git4Idea</depends>
 
     <extensions defaultExtensionNs="com.intellij">
-        <projectConfigurable groupId="tools" displayName="Intelligent History"
+        <projectConfigurable parentId="tools" displayName="Intelligent History"
                              instance="com.alisli.intelligenthistory.settings.JiraConfigurable"/>
         <projectService serviceImplementation="com.alisli.intelligenthistory.settings.JiraConfig"/>
         <toolWindow id="Jira Metadata" secondary="false" icon="MyIcons.Jira" anchor="left"


### PR DESCRIPTION
Fixed a bug where getting the credentials for a `null` key would throw a null pointer exception. This resulted in an endlessly loading panel when visiting the settings for the plugin. 